### PR TITLE
Update backend URL references across documentation

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -97,7 +97,7 @@ These endpoints are part of the backend's API.
       "frontendUrl": "https://localhost:3000",
       "stateParam": "dev",
       "nodeEnv": "production",
-      "backendUrl": "https://vikings-osm-event-manager.onrender.com"
+      "backendUrl": "https://vikings-osm-backend.onrender.com"
     }
     ```
 

--- a/docs/api/other_endpoints.md
+++ b/docs/api/other_endpoints.md
@@ -25,8 +25,8 @@ This section covers miscellaneous helper or debugging endpoints available in the
         "frontendUrl": "https://vikings-eventmgmt.onrender.com", // Or "https://localhost:3000" if state=dev
         "stateParam": "Not set", // Or the value of the 'state' query parameter if provided
         "nodeEnv": "production", // Or "development"
-        "backendUrl": "https://vikings-osm-event-manager.onrender.com", // Backend's configured URL
-        "authUrl": "https://www.onlinescoutmanager.co.uk/oauth/authorize?client_id=YOUR_CLIENT_ID&redirect_uri=https%3A%2F%2Fvikings-osm-event-manager.onrender.com%2Foauth%2Fcallback&scope=section%3Amember%3Aread%20section%3Aprogramme%3Aread%20section%3Aevent%3Aread%20section%3Aflexirecord%3Awrite&response_type=code"
+        "backendUrl": "https://vikings-osm-backend.onrender.com", // Backend's configured URL
+        "authUrl": "https://www.onlinescoutmanager.co.uk/oauth/authorize?client_id=YOUR_CLIENT_ID&redirect_uri=https%3A%2F%2Fvikings-osm-backend.onrender.com%2Foauth%2Fcallback&scope=section%3Amember%3Aread%20section%3Aprogramme%3Aread%20section%3Aevent%3Aread%20section%3Aflexirecord%3Awrite&response_type=code"
         // The authUrl is constructed using the backend's environment variables.
         // Replace YOUR_CLIENT_ID with the actual client ID.
     }

--- a/docs/dynamic-redirect.md
+++ b/docs/dynamic-redirect.md
@@ -7,12 +7,12 @@ The backend OAuth callback uses the `state` parameter to determine which fronten
 
 **For Development (localhost):**
 ```javascript
-const authUrl = `https://www.onlinescoutmanager.co.uk/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent('https://vikings-osm-event-manager.onrender.com/oauth/callback')}&state=dev&scope=section%3Amember%3Aread%20section%3Aprogramme%3Aread%20section%3Aevent%3Aread%20section%3Aflexirecord%3Awrite&response_type=code`;
+const authUrl = `https://www.onlinescoutmanager.co.uk/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent('https://vikings-osm-backend.onrender.com/oauth/callback')}&state=dev&scope=section%3Amember%3Aread%20section%3Aprogramme%3Aread%20section%3Aevent%3Aread%20section%3Aflexirecord%3Awrite&response_type=code`;
 ```
 
 **For Production:**
 ```javascript
-const authUrl = `https://www.onlinescoutmanager.co.uk/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent('https://vikings-osm-event-manager.onrender.com/oauth/callback')}&state=prod&scope=section%3Amember%3Aread%20section%3Aprogramme%3Aread%20section%3Aevent%3Aread%20section%3Aflexirecord%3Awrite&response_type=code`;
+const authUrl = `https://www.onlinescoutmanager.co.uk/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent('https://vikings-osm-backend.onrender.com/oauth/callback')}&state=prod&scope=section%3Amember%3Aread%20section%3Aprogramme%3Aread%20section%3Aevent%3Aread%20section%3Aflexirecord%3Awrite&response_type=code`;
 ```
 
 ## Backend Logic
@@ -26,7 +26,7 @@ const getFrontendUrl = () => {
 ```
 
 ## OSM Application Settings
-Callback URL: `https://vikings-osm-event-manager.onrender.com/oauth/callback`
+Callback URL: `https://vikings-osm-backend.onrender.com/oauth/callback`
 
 ## Testing
 - Test development: `https://backend.com/oauth/debug?state=dev`

--- a/docs/oauth-flow-updated.md
+++ b/docs/oauth-flow-updated.md
@@ -25,6 +25,6 @@ The OAuth flow has been simplified to use only the backend-handled callback:
 - `state=prod` → Redirects to production frontend
 
 ### OSM Application Configuration:
-- Callback URL: `https://vikings-osm-event-manager.onrender.com/oauth/callback`
+- Callback URL: `https://vikings-osm-backend.onrender.com/oauth/callback`
 
 The codebase is now cleaner with only the active OAuth implementation.

--- a/server.js
+++ b/server.js
@@ -267,7 +267,7 @@ app.get('/oauth/debug', (req, res) => {
     refererHeader: req.get('Referer') || 'Not set',
     nodeEnv: process.env.NODE_ENV || 'Not set',
     backendUrl: process.env.BACKEND_URL || 'Not set',
-    authUrl: `https://www.onlinescoutmanager.co.uk/oauth/authorize?client_id=${process.env.OAUTH_CLIENT_ID}&redirect_uri=${encodeURIComponent(process.env.BACKEND_URL || 'https://vikings-osm-event-manager.onrender.com')}/oauth/callback&scope=section%3Amember%3Aread%20section%3Aprogramme%3Aread%20section%3Aevent%3Aread%20section%3Aflexirecord%3Awrite&response_type=code`
+    authUrl: `https://www.onlinescoutmanager.co.uk/oauth/authorize?client_id=${process.env.OAUTH_CLIENT_ID}&redirect_uri=${encodeURIComponent(process.env.BACKEND_URL || 'https://vikings-osm-backend.onrender.com')}/oauth/callback&scope=section%3Amember%3Aread%20section%3Aprogramme%3Aread%20section%3Aevent%3Aread%20section%3Aflexirecord%3Awrite&response_type=code`
   });
 });
 
@@ -310,7 +310,7 @@ app.get('/oauth/callback', async (req, res) => {
       client_id: process.env.OAUTH_CLIENT_ID,
       client_secret: process.env.OAUTH_CLIENT_SECRET,
       code: code,
-      redirect_uri: `${process.env.BACKEND_URL || 'https://vikings-osm-event-manager.onrender.com'}/oauth/callback`
+      redirect_uri: `${process.env.BACKEND_URL || 'https://vikings-osm-backend.onrender.com'}/oauth/callback`
     };
     
     console.log('Token exchange payload:', {


### PR DESCRIPTION
## Summary
- Update all references from `vikings-osm-event-manager.onrender.com` to `vikings-osm-backend.onrender.com`
- Affects documentation, OAuth configuration, and example URLs
- Aligns with repository rename and new deployment URL

## Changes
- `docs/api/auth.md` - Updated API examples
- `docs/api/other_endpoints.md` - Updated endpoint references  
- `docs/dynamic-redirect.md` - Updated redirect documentation
- `docs/oauth-flow-updated.md` - Updated OAuth flow examples
- `server.js` - Updated default backend URL fallback

## Test plan
- [x] No functional changes to API behavior
- [x] Documentation now reflects correct deployment URL
- [ ] Verify OAuth flows still work with new URLs

🤖 Generated with [Claude Code](https://claude.ai/code)